### PR TITLE
Review pass across all units

### DIFF
--- a/units/en/unit0/introduction.mdx
+++ b/units/en/unit0/introduction.mdx
@@ -1,6 +1,6 @@
 # Welcome to The Context Course
 
-This course is about **context engineering** for AI code agents: structuring knowledge so an agent can find what it needs, when it needs it.
+This course is about **context engineering** for AI code agents: structuring knowledge so an agent can efficiently find what it needs, when it needs it to improve its generated outputs.
 
 ## The Key Skill for Code Agents
 
@@ -120,6 +120,9 @@ Every unit follows the same shape: an introduction, conceptual material, practic
 **Ben Burtenshaw** — ML Engineer, Hugging Face
 
 Ben focuses on LLM applications with emphasis on post-training and agentic approaches. He leads initiatives around agent best practices and context engineering at Hugging Face.
+
+**Atin Kumar Singh** — ML Researcher & Founding Engineer @ Data Pigeon
+Atin works on agentic systems and multimodal benchmarking at the DARE Lab, UC Davis, and is a founding engineer at Data Pigeon. He contributed to technical review and content across all units of this course.
 
 ## Connect with the Community
 

--- a/units/en/unit1/introduction.mdx
+++ b/units/en/unit1/introduction.mdx
@@ -4,7 +4,9 @@
 
 ## Why Context Engineering Matters
 
-Ask Claude Code to "publish a dataset to Hugging Face" with no extra context, and the agent has to guess at authentication, schema, and required fields. It may get stuck, ask clarifying questions, or fill in plausible but wrong values.
+Without the right context, even a capable agent is working blind. It fills gaps with guesses, asks questions it shouldn't need to ask, and wastes time on work that has to be redone. They can start failing on ordinary tasks instead of just hard tasks. Instead of needing a better model, the agent needs better context.
+
+For example, ask Claude Code to "publish a dataset to Hugging Face" with no extra context, and the agent has to guess at authentication, schema, and required fields. It may get stuck, ask clarifying questions, or fill in plausible but wrong values. This wastes time and tokens.
 
 Give the same agent authentication instructions, the dataset schema, the API format, and pointers to common pitfalls, and the task finishes faster and more reliably.
 
@@ -20,6 +22,8 @@ This principle runs through the rest of the course. It's the same reason communi
 A **skill** is a self-contained package of knowledge that makes an agent good at one specific task. Skills are portable across projects and agents, reusable once installed, structured in a format agents can parse, and extensible through links to scripts and APIs.
 
 A skill is essentially an onboarding document for an agent: the same kind of step-by-step guide you'd give a new colleague, but written so the agent can load it on demand.
+
+They typically exist in the form of a directory that contains a `SKILL.md` markdown document with metadata and instructions. The directory is usually filled with key metadata, scripts and references that vary between different types of skills.
 
 ## From Prompts to Portable Knowledge
 

--- a/units/en/unit1/skill-format.mdx
+++ b/units/en/unit1/skill-format.mdx
@@ -117,6 +117,7 @@ Brief description of what the skill teaches and typical use cases.
 ## Step-by-Step Guide
 
 ### 1. Authentication
+...
 ```
 
 ### Content Guidelines
@@ -433,7 +434,7 @@ Keep skills efficient:
 | scripts/ | Individual scripts < 500 lines | Easy to understand and modify |
 | Total skill | < 2 MB | Quick download and indexing |
 
-Move large reference materials to external repositories if needed.
+Move large reference materials to external repositories if needed. This keeps the total skill itself small and lightweight, allowing the agent to perform quick downloading and indexing, only pulling heavy reference materials from external sources when needed.
 
 ## Writing Tips
 

--- a/units/en/unit1/using-skills.mdx
+++ b/units/en/unit1/using-skills.mdx
@@ -93,7 +93,7 @@ Or, you can install the entire Hugging Face plugin:
 /plugins
 ```
 
-Then select 'Hugging Face' and click 'Install'.
+Then select 'Hugging Face' and click 'Install plugin'.
 
 </hfoption>
 

--- a/units/en/unit1/what-are-skills.mdx
+++ b/units/en/unit1/what-are-skills.mdx
@@ -4,7 +4,7 @@ This lesson looks at skills in more depth: what they are, what problems they sol
 
 ## The Problem: Agents Without Context
 
-Imagine you're working on the Hugging Face Hub and ask your code agent:
+Building on the Claude Code example from last section, imagine you're working on the Hugging Face Hub and ask your code agent:
 
 > "Train a model on this dataset and publish it when done."
 
@@ -58,7 +58,7 @@ For example, with a dataset publishing skill, the same agent would:
 
 ### The Traditional Approach: Prompt-Based Context
 
-You might try to solve this with a detailed prompt:
+Without skills, you might try to solve this with a detailed prompt:
 
 ```
 You are a Hugging Face expert. When publishing models:

--- a/units/en/unit2/building-servers.mdx
+++ b/units/en/unit2/building-servers.mdx
@@ -290,6 +290,12 @@ Launch with `mcp_server=True` to automatically:
 
 Your functions are now both web UI components AND MCP tools.
 
+ > [!NOTE]
+> The purpose of exposing MCP features as UI components is:
+> - It allows non-agent users to interact with the tools in a browser.
+> - It gives a quick human test harness for the tools.
+>   
+> Agent-only setups do **not** require UI.
 ## Advanced Gradio MCP Features
 
 ### Resources in Gradio

--- a/units/en/unit2/gradio-mcp.mdx
+++ b/units/en/unit2/gradio-mcp.mdx
@@ -1,6 +1,6 @@
 # Gradio MCP Integration: Web UIs + MCP Servers
 
-Gradio can turn the same functions into both a web UI and an MCP server. Pass `mcp_server=True` to `launch()` and your Gradio app exposes each function as a tool agents can call.
+As we saw previously, Gradio can turn the same functions into both a web UI and an MCP server. Pass `mcp_server=True` to `launch()` and your Gradio app exposes each function as a tool that agents can call.
 
 ## What Is Gradio MCP Integration?
 
@@ -12,6 +12,21 @@ Gradio is a Python library for building web UIs for machine learning models and 
 4. Handles JSON-RPC serialization and protocol details
 
 You get two interfaces for the price of one: humans use the web UI, agents use MCP.
+
+## Installing Gradio with MCP Support
+
+Install Gradio with MCP support:
+
+```bash
+pip install "gradio[mcp]"
+```
+
+Create a `requirements.txt` for deployment:
+
+```
+gradio>=4.0.0
+```
+
 
 ## Creating a Simple Gradio MCP App
 
@@ -127,20 +142,6 @@ if __name__ == "__main__":
 ```
 
 Each function becomes a separate MCP tool that agents can call independently.
-
-## Installing Gradio with MCP Support
-
-Install Gradio with MCP support:
-
-```bash
-pip install "gradio[mcp]"
-```
-
-Create a `requirements.txt` for deployment:
-
-```
-gradio>=4.0.0
-```
 
 ## Advanced Gradio MCP Features
 

--- a/units/en/unit2/key-concepts.mdx
+++ b/units/en/unit2/key-concepts.mdx
@@ -49,19 +49,22 @@ MCP servers expose three kinds of capabilities to clients:
 Tools are callable functions that agents invoke to perform actions or retrieve data. Each tool has a unique name (like `search_github`), a description of what it does, a JSON Schema defining its input parameters, and the actual function implementation. When an agent reasons that a tool would help with the current task, it calls the tool with appropriate parameters, the server executes it and returns results, and the agent incorporates those results into its reasoning. Tools are model-controlled — the agent decides whether and when to call them. They can modify state (writing files, sending messages), include error handling, and return structured or unstructured results.
 
 ### Resources
-Resources are read-only data sources that agents can access for information. Each resource has a URI (like `file:///path/to/code.py`), a human-readable name, a description, and a MIME type. When an agent needs information to reason about a problem, it requests a resource by URI, the server retrieves the content, and the agent uses it as context. Unlike tools, resources are application-controlled — the host decides what to expose. They're always available without being explicitly called, making them ideal for static or semi-static data like project files, documentation, or configuration.
+Resources are read-only data sources that agents can access for information. Each resource has a URI (like `file:///path/to/code.py`), a human-readable name, a description, and a MIME type. When an agent needs information to reason about a problem, it requests a resource by URI, the server retrieves the content, and the agent uses it as context. Unlike tools, resources are application-controlled — the host determines what is exposed. They're always available without being explicitly called, making them ideal for static or semi-static data like project files, documentation, or configuration.
 
 ### Prompts
-Prompts are instruction templates that guide agent behavior for specific contexts or domains. Each prompt has a name (like `code_review`), a description of when it applies, optional arguments for dynamic behavior, and the actual template text. When an agent recognizes a situation where a prompt applies, it requests the prompt (optionally with arguments), receives the instantiated text, and uses it to structure its reasoning. Prompts are user-controlled — they're deployed separately and updated independently. They're non-executable text instructions, ideal for standardizing approaches to recurring tasks like code reviews or security audits.
+Prompts are instruction templates that agents can request to help guide their own behavior for specific contexts or domains. Each prompt has a name (like `code_review`), a description of when it applies, optional arguments for dynamic behavior, and the actual template text. When an agent recognizes a situation where a prompt applies, it requests the prompt (optionally with arguments), receives the instantiated text, and uses it to structure its reasoning. Prompts are user-controlled — they're deployed separately and updated independently. They're non-executable text instructions, ideal for standardizing approaches to recurring tasks like code reviews or security audits.
 
 ![The three MCP capability types: Tools, Resources, and Prompts](https://huggingface.co/datasets/mcp-course/images/resolve/main/unit2/capability-types.svg)
 
 > [!NOTE]
-> 90% of MCP usage is for tools.
+> On average, about ~90% of MCP usage is for tools.
 
 ## Communication Protocol: JSON-RPC Over Transports
 
 MCP uses **JSON-RPC 2.0** as its messaging protocol. Every request and response is a JSON-RPC message. The protocol is transport-agnostic—the same JSON-RPC format works over any transport.
+
+> [!NOTE]
+> A transport can be defined as any communication channel that carries a message. For example, processes that exist on the same machine (stdio), or connect over a network connection (e.g. HTTP).
 
 A typical client request to call a tool:
 ```json
@@ -109,9 +112,34 @@ For **local connections** where the server runs on your machine:
 - Most secure (no network exposure)
 
 Configuration:
+
+<hfoptions id="tool">
+
+<hfoption id="Claude Code">
+
 ```bash
 claude mcp add --transport stdio my-server -- python /path/to/server.py
 ```
+
+</hfoption>
+
+<hfoption id="Codex">
+
+```bash
+codex mcp add my-server -- python /path/to/server.py
+```
+
+</hfoption>
+
+<hfoption id="OpenCode">
+
+```bash
+opencode mcp add my-server --command "python" --args "/path/to/server.py"
+```
+
+</hfoption>
+
+</hfoptions>
 
 ### Streamable HTTP Transport
 For **remote connections** where the server runs elsewhere:

--- a/units/en/unit2/mcp-clients.mdx
+++ b/units/en/unit2/mcp-clients.mdx
@@ -375,7 +375,7 @@ Should return a valid response if the server is running.
 
 ## Configuration Best Practices
 
-Use environment variables for API keys and secrets, absolute paths for local server scripts, and one server per capability area (keep GitHub and Slack servers separate). Test servers locally first before deploying to the cloud. Use descriptive server names that indicate what each server provides, document your configuration, and keep configs in version control — without secrets.
+Use environment variables for API keys and secrets, absolute paths for local server scripts, and one server per capability area (e.g. keep GitHub and Slack servers separate). Test servers locally first before deploying to the cloud. Use descriptive server names that indicate what each server provides, document your configuration, and keep configs in version control — without secrets.
 
 ## Key Takeaways
 

--- a/units/en/unit3/building-plugins.mdx
+++ b/units/en/unit3/building-plugins.mdx
@@ -431,7 +431,7 @@ If you edit the plugin file or the `plugin` list in `opencode.json`, restart Ope
 
 ## Complete Plugin Structure
 
-For Claude Code and Codex, the final manifest-first plugin directory looks like:
+For Claude Code and Codex (assuming you use both), the final manifest-first plugin directory looks like:
 
 ```
 text-processor-plugin/

--- a/units/en/unit3/introduction.mdx
+++ b/units/en/unit3/introduction.mdx
@@ -22,3 +22,5 @@ For a solo developer, a plugin skips setup: install a Python-linting plugin or a
 ## Key Terminology
 
 A **skill** is a reusable prompt plus metadata. An **MCP server** is a standardized tool provider for file I/O, API calls, or database queries. An **integration** connects to an external service like GitHub, Slack, or Google Drive. A **manifest** is the metadata file used by manifest-first plugin systems like Claude Code and Codex. A **marketplace** is a catalog where plugins are published and discovered.
+
+First up, we are going to take an in-depth look at the anatomy of plugins.

--- a/units/en/unit4/hands-on.mdx
+++ b/units/en/unit4/hands-on.mdx
@@ -14,7 +14,7 @@ mkdir code-quality-pipeline
 cd code-quality-pipeline
 
 # Create files
-mkdir .claude/agents
+mkdir -p .claude/agents
 touch main.py
 touch .claude/CLAUDE.md
 ```

--- a/units/en/unit4/introduction.mdx
+++ b/units/en/unit4/introduction.mdx
@@ -74,16 +74,16 @@ Parent orchestrates:
    └─ Subagent: Test code (using code from stage 2)
 ```
 
-Clear separation of concerns, easy to track progress.
+Clear separation of concerns, easy to track progress. 
+
+A single agent could handle these stages sequentially, but subagents give each stage an isolated context window. The testing subagent receives only the finished code, not the full history of design discussions and implementation decisions that built up in the parent's context. This keeps each stage focused and prevents context bloat from degrading output quality on longer pipelines. It also allows the subagent to be more nit-picky and critical of the work the previous agent did and ensures outputs are as robust as possible.
 
 ## The Strong Signal: "10+ Files"
 
-If you find yourself saying:
+A strong signal to determine whether you need to use subagents in your workflow is if you find yourself thinking something along the lines of:
 - "I need to read 10+ files to understand this"
 - "I'm doing 3+ independent pieces of work"
 - "I want a second opinion on this"
-
-**→ That's when subagents shine.**
 
 ## Subagent Benefits
 
@@ -95,4 +95,4 @@ Avoid subagents for sequential dependent work where task B needs output from tas
 
 ## What You'll Learn
 
-This unit covers subagent patterns (fan-out/fan-in, pipeline, supervisor, swarm), the signals that tell you a task wants subagents, how to invoke them in Claude Code and Codex, and a hands-on research–implement–review pipeline.
+This unit covers subagent patterns (fan-out/fan-in, pipeline, supervisor, swarm), the signals that tell you a task needs subagents, how to invoke them in Claude Code and Codex, and a hands-on research–implement–review pipeline.

--- a/units/en/unit4/patterns.mdx
+++ b/units/en/unit4/patterns.mdx
@@ -1,6 +1,6 @@
 # Subagent Patterns
 
-Multi-agent workflows tend to fall into a handful of shapes. Four of them cover almost everything you'll build.
+Multi-agent workflows tend to fall into a handful of shapes. We will go over 4 of them that cover almost anything you would build.
 
 ## Pattern 1: Fan-Out / Fan-In
 
@@ -138,9 +138,9 @@ parent_agent:
 
 ```
 Parent: "Design new API"
-├─ Subagent 1 (Architect): Design REST structure
-├─ Subagent 2 (Security): Identify vulnerabilities
-├─ Subagent 3 (Performance): Identify bottlenecks
+├─ Subagent 1 (Architect): Review structure
+├─ Subagent 2 (Security): Review for vulnerabilities
+├─ Subagent 3 (Performance): Review for bottlenecks
 
 Parent: Incorporate feedback → Final design
 ```

--- a/units/en/unit4/using-subagents.mdx
+++ b/units/en/unit4/using-subagents.mdx
@@ -118,7 +118,9 @@ Or define which subagent should run which skill:
 ---
 name: hf-researcher
 description: Hugging Face specialist
-tools: hf-api-search, hf-dataset-fetch
+skills: 
+	- hf-api-search 
+	- hf-dataset-fetch
 model: sonnet
 ---
 You are an expert at finding and evaluating models on Hugging Face.

--- a/units/en/unit6/agent-loop.mdx
+++ b/units/en/unit6/agent-loop.mdx
@@ -134,7 +134,7 @@ def exec_cmd(args):
     if args[0] not in ALLOW_COMMANDS:
         raise PermissionError(f"Command {args[0]} not allowed")
     result = subprocess.run(args, capture_output=True, timeout=TIMEOUT_S, text=True)
-    return result.stdout[:MAX_CHARS]  # Limit output
+    return (result.stdout or result.stderr)[:MAX_CHARS]  # Limit output
 
 def final_answer(value):
     """Agent calls this when task is complete."""

--- a/units/en/unit6/introduction.mdx
+++ b/units/en/unit6/introduction.mdx
@@ -9,7 +9,7 @@ Nano Harness is a ~220-line Python agent built for reading, not production. It s
 
 ## Why start from scratch?
 
-First, learning from scratch is a great way to understand how anything works under the hood.
+Learning from scratch is a great way to understand how anything works under the hood.
 
 Reading a minimal harness makes the design choices legible: when to retry, how to parse output, how to handle errors, and where the security boundary sits. This unit uses `zai-org/GLM-5.1` via Hugging Face Inference Providers as the single model, so the only moving parts are the loop and the tools.
 
@@ -19,11 +19,11 @@ Nano Harness is a ~220-line Python agent framework that:
 
 1. **Takes a task** — "Inspect the workspace and provide a summary"
 2. **Calls an LLM** — Uses OpenAI-compatible API (defaults to HF router)
-3. **Parses Python code** — Model outputs executable Python code
+3. **Generates Python code** — Model outputs executable Python code that will help complete the task
 4. **Executes safely** — In a sandboxed environment with allowed tools
 5. **Observes results** — stdout, stderr, exceptions
 6. **Updates context** — Feeds observations back to the model
-7. **Repeats** — Until the task is done or we hit step limit
+7. **Repeats** — Until the task is done or we hit step limit (we're assuming 50 steps in our implementation)
 
 ## Key Features
 

--- a/units/en/unit6/tools-and-sandboxing.mdx
+++ b/units/en/unit6/tools-and-sandboxing.mdx
@@ -90,7 +90,7 @@ def exec_cmd(args):
             timeout=TIMEOUT_S,  # e.g., 30 seconds
             text=True
         )
-        return clip(result.stdout, MAX_CHARS)
+        return (result.stdout or result.stderr)[:MAX_CHARS]
     except subprocess.TimeoutExpired:
         return "Error: Command timed out"
 ```
@@ -156,6 +156,7 @@ When executing agent code:
 ```python
 # Only these functions are available
 exec_globals = {
+    "__builtins__": {}, # need to explicitly remove builtins
     "list_dir": list_dir,
     "read_file": read_file,
     "write_file": write_file,


### PR DESCRIPTION
Technical fixes:
- `exec_cmd` now returns `stdout or stderr` instead of stdout only
- `exec_globals` explicitly sets `__builtins__: {}` to actually close the sandbox
- Fixed `skills:` vs `tools:` in subagent frontmatter example
- Fixed missing `-p` on `mkdir` in unit 4 hands-on

Content additions:
- Added Codex and OpenCode CLI commands for MCP stdio transport
- Added transport definition note after JSON-RPC section
- Added pipeline subagent justification in unit 4 intro
- Moved Gradio install section before the examples
- Added co-author to instructors section

Clarity fixes:
- Bridging line between unit 1 pages to reduce repeated motivation example
- Rewrote "Strong Signal" bullet section
- Fixed swarm pattern visualization labels
- Misc wording fixes across units 1-5