### PR TITLE
Expand Unit 5 hook coverage and update Atin bio

### DIFF
--- a/units/en/unit0/introduction.mdx
+++ b/units/en/unit0/introduction.mdx
@@ -136,7 +136,8 @@ Every unit follows the same shape: an introduction, conceptual material, practic
 Ben focuses on LLM applications with emphasis on post-training and agentic approaches. He leads initiatives around agent best practices and context engineering at Hugging Face.
 
 **Atin Kumar Singh** — ML Researcher & Founding Engineer @ Data Pigeon
-Atin works on agentic systems and multimodal benchmarking at the DARE Lab, UC Davis, and is a founding engineer at Data Pigeon. He contributed to technical review and content across all units of this course.
+
+Atin's research focuses on world models and robotics at the DARE Lab, UC Davis. He is a founding engineer at Data Pigeon, an AI-driven EV charging platform. His broader work spans applied ML and infrastructure for AI agents.
 
 ## Connect with the Community
 

--- a/units/en/unit5/hands-on.mdx
+++ b/units/en/unit5/hands-on.mdx
@@ -229,21 +229,23 @@ Make sure `~/.codex/config.toml` has:
 codex_hooks = true
 ```
 
+These examples assume `jq` and `curl` are installed and available on your `PATH`.
+
 `.codex/hooks.json`:
 
 ```json
 {
   "hooks": {
-    "PreToolUse":  [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "jq -c '{platform:\"codex\", event:\"PreToolUse\", tool:.tool_name, args:.tool_input}' | curl -s --max-time 2 -X POST -H 'Content-Type: application/json' --data-binary @- http://localhost:8000/event" }] }],
-    "PostToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "jq -c '{platform:\"codex\", event:\"PostToolUse\", tool:.tool_name, result:.tool_response}' | curl -s --max-time 2 -X POST -H 'Content-Type: application/json' --data-binary @- http://localhost:8000/event" }] }],
-    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "jq -c '{platform:\"codex\", event:\"UserPromptSubmit\", args:.prompt}' | curl -s --max-time 2 -X POST -H 'Content-Type: application/json' --data-binary @- http://localhost:8000/event" }] }],
-    "Stop":            [{ "hooks": [{ "type": "command", "command": "jq -c '{platform:\"codex\", event:\"Stop\", args:.last_assistant_message}' | curl -s --max-time 2 -X POST -H 'Content-Type: application/json' --data-binary @- http://localhost:8000/event" }] }],
-    "SessionStart":    [{ "hooks": [{ "type": "command", "command": "jq -c '{platform:\"codex\", event:\"SessionStart\"}' | curl -s --max-time 2 -X POST -H 'Content-Type: application/json' --data-binary @- http://localhost:8000/event" }] }]
+    "PreToolUse":  [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "jq -c '{platform:\"codex\", event:\"PreToolUse\", tool:.tool_name, args:.tool_input}' | curl -s --max-time 2 -X POST -H 'Content-Type: application/json' --data-binary @- http://localhost:8000/event || true" }] }],
+    "PostToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "jq -c '{platform:\"codex\", event:\"PostToolUse\", tool:.tool_name, args:.tool_response}' | curl -s --max-time 2 -X POST -H 'Content-Type: application/json' --data-binary @- http://localhost:8000/event || true" }] }],
+    "UserPromptSubmit": [{ "hooks": [{ "type": "command", "command": "jq -c '{platform:\"codex\", event:\"UserPromptSubmit\", args:.prompt}' | curl -s --max-time 2 -X POST -H 'Content-Type: application/json' --data-binary @- http://localhost:8000/event || true" }] }],
+    "Stop":            [{ "hooks": [{ "type": "command", "command": "jq -c '{platform:\"codex\", event:\"Stop\", args:.last_assistant_message}' | curl -s --max-time 2 -X POST -H 'Content-Type: application/json' --data-binary @- http://localhost:8000/event || true" }] }],
+    "SessionStart":    [{ "hooks": [{ "type": "command", "command": "jq -c '{platform:\"codex\", event:\"SessionStart\"}' | curl -s --max-time 2 -X POST -H 'Content-Type: application/json' --data-binary @- http://localhost:8000/event || true" }] }]
   }
 }
 ```
 
-Each hook reshapes Codex's payload into the normalized `{platform, event, tool, args}` shape, then POSTs it. The `--max-time 2` on `curl` protects the agent from hanging if the dashboard is slow.
+Each hook reshapes Codex's payload into the normalized `{platform, event, tool, args}` shape, then POSTs it. The `--max-time 2` on `curl` protects the agent from hanging if the dashboard is slow, and `|| true` keeps logging best-effort if the dashboard is offline.
 
 Restart Codex to pick up the hooks, then try:
 
@@ -414,10 +416,22 @@ Add a second hook handler for `PreToolUse` that runs before the dashboard logger
 }
 ```
 
-Now the same `PreToolUse` event does two things: denies obviously destructive shell patterns (exit code `2` with a stderr message) and logs everything else to the dashboard. Try asking the agent to run `rm -rf ~/` — you'll see it refuse, and you'll see the guardrail event in the dashboard.
+Now the same `PreToolUse` event does two things: denies obviously destructive shell patterns (exit code `2` with a stderr message) and logs everything else to the dashboard. Create a disposable test folder:
+
+```bash
+mkdir -p /tmp/hook-guardrail-demo-delete-me
+```
+
+Then ask the agent to run:
+
+```text
+rm -rf /tmp/hook-guardrail-demo-delete-me
+```
+
+You'll see it refuse before the command executes, and you'll see the guardrail event in the dashboard.
 
 > [!TIP]
-> The equivalent OpenCode guard is a `throw new Error("blocked: dangerous shell pattern")` inside `"tool.execute.before"`. For Codex, the hook prints `jq -c '{hookSpecificOutput:{hookEventName:"PreToolUse", permissionDecision:"deny", permissionDecisionReason:"…"}}'` on stdout instead of exiting 2.
+> The equivalent OpenCode guard is a `throw new Error("blocked: dangerous shell pattern")` inside `"tool.execute.before"`. For Codex, the hook can either exit `2` with a stderr reason or print `jq -c '{hookSpecificOutput:{hookEventName:"PreToolUse", permissionDecision:"deny", permissionDecisionReason:"…"}}'` on stdout.
 
 ## Step 5: Deploy (Optional)
 
@@ -439,17 +453,20 @@ agent-activity-dashboard/
 │   └── settings.json                   # Claude Code hooks
 ├── .codex/
 │   └── hooks.json                      # Codex hooks
-└── .opencode/
-    └── plugins/
-        └── dashboard.ts                # OpenCode plugin
+├── .opencode/
+│   └── plugins/
+│       └── dashboard.ts                # OpenCode plugin
+└── .pi/
+    └── extensions/
+        └── dashboard.ts                # Pi extension
 ```
 
 ## Best Practices Demonstrated
 
-This project shows how to pick the right event for observability (`PreToolUse` and `PostToolUse`), how to collapse three different payload shapes into one normalized record, and how to use exit codes / `hookSpecificOutput` / thrown errors to enforce policy. The Gradio + FastAPI pattern — one process, two surfaces — keeps the whole thing short and makes it easy to host on Spaces.
+This project shows how to pick the right event for observability (`PreToolUse` and `PostToolUse`), how to collapse four different payload shapes into one normalized record, and how to use exit codes / `hookSpecificOutput` / thrown errors / returned values to enforce policy. The Gradio + FastAPI pattern — one process, two surfaces — keeps the whole thing short and makes it easy to host on Spaces.
 
 ## Key Takeaways
 
-A hook is only useful if its output goes somewhere. A Gradio dashboard is a fast way to turn raw hook events into something you can actually learn from: you can watch an agent work, see where it's stuck, and prove that guardrails fire. The same dashboard works across Claude Code, Codex, and OpenCode because the event shape is narrow and the normalizer is small.
+A hook is only useful if its output goes somewhere. A Gradio dashboard is a fast way to turn raw hook events into something you can actually learn from: you can watch an agent work, see where it's stuck, and prove that guardrails fire. The same dashboard works across Claude Code, Codex, OpenCode, and Pi because the event shape is narrow and the normalizer is small.
 
 Next, one more quiz to wrap up the unit.

--- a/units/en/unit5/hook-events.mdx
+++ b/units/en/unit5/hook-events.mdx
@@ -21,14 +21,14 @@ At the abstract level, every agent session moves through the same phases:
 └─────────────────────────────────────────────┘
 ```
 
-Any hook system worth using exposes at least these five moments. The platforms in this course all do — they just use different names and offer different amounts of extra granularity.
+This is the shared mental model. The platforms in this course map onto these moments with different names, different configuration surfaces, and a few gaps or extra events.
 
 ## Events by Platform
 
 <hfoptions id="tool">
 <hfoption id="Claude Code">
 
-Claude Code has the richest event set of the three platforms. Every event uses `PascalCase` and is configured in `.claude/settings.json` (or inside a plugin's `hooks/hooks.json`).
+Claude Code has the richest event set of the four platforms. Every event uses `PascalCase` and is configured in `.claude/settings.json` (or inside a plugin's `hooks/hooks.json`).
 
 **Core lifecycle events:**
 - `SessionStart` — New session begins (fresh, resume, or compaction continuation).
@@ -36,7 +36,7 @@ Claude Code has the richest event set of the three platforms. Every event uses `
 - `UserPromptSubmit` — User submitted a prompt, before the model sees it.
 - `PreToolUse` — Before a tool call runs.
 - `PermissionRequest` — Permission prompt about to be shown.
-- `PermissionDenied` — User denied a permission.
+- `PermissionDenied` — A tool call was denied by the auto-mode classifier.
 - `PostToolUse` — After a tool call returns.
 - `PostToolUseFailure` — Tool call failed.
 - `Stop` — Turn finished.
@@ -52,7 +52,7 @@ Claude Code has the richest event set of the three platforms. Every event uses `
 - `PreCompact`, `PostCompact` — Context compaction about to happen / just finished.
 - `ConfigChange`, `Notification` — Settings changed; Claude raised a notification.
 
-Each event can match on tool name, command pattern, or permission rules. Matchers use the same permission-rule syntax you see elsewhere in Claude Code (e.g. `"matcher": "Bash"`, `"matcher": "Edit(src/**)"`).
+Matcher groups filter on event-specific fields. Tool events match tool names (for example, `"matcher": "Bash"` or `"matcher": "Edit|Write"`), while handler-level `if` conditions can use permission-rule syntax to inspect tool arguments (for example, `"if": "Bash(rm *)"`).
 
 </hfoption>
 <hfoption id="Codex">
@@ -66,15 +66,16 @@ codex_hooks = true
 
 Codex ships a smaller core set of events, all `PascalCase`, configured in `~/.codex/hooks.json` or `<repo>/.codex/hooks.json`:
 
-- `SessionStart` — Session begins. Matcher filters the `source` field: `startup` or `resume`.
+- `SessionStart` — Session begins. Matcher filters the `source` field: `startup`, `resume`, or `clear`.
 - `UserPromptSubmit` — User prompt submitted.
-- `PreToolUse` — Before a tool call. Today this only fires for the `Bash` tool.
-- `PostToolUse` — After a tool call. Today this also only fires for `Bash`.
+- `PreToolUse` — Before a supported tool call, including `Bash`, `apply_patch` (`Edit|Write` aliases), and MCP tools.
+- `PermissionRequest` — Permission prompt about to be shown.
+- `PostToolUse` — After a supported tool call, including `Bash`, `apply_patch` (`Edit|Write` aliases), and MCP tools.
 - `Stop` — Turn finished.
 
-The Codex event set is intentionally close to the classic Claude Code lifecycle, which makes cross-agent hook scripts easier to share — but note the current Bash-only scope on the tool events.
+The Codex event set is intentionally close to the classic Claude Code lifecycle, which makes cross-agent hook scripts easier to share — but note that the tool-event surface is still narrower than Claude Code's and does not intercept every tool path.
 
-Matchers are regexes evaluated against `tool_name` for tool events or `source` for `SessionStart`. Windows is not yet supported.
+Matchers are regexes evaluated against `tool_name` for tool events or `source` for `SessionStart`. Codex hooks are changing quickly, so small details may differ between Codex versions. The examples below show the event set used in this course.
 
 </hfoption>
 <hfoption id="OpenCode">
@@ -158,7 +159,7 @@ Command hooks receive JSON on stdin. Common fields:
 }
 ```
 
-Turn-scoped events add `turn_id`. Tool events add `tool_name`, `tool_use_id`, and `tool_input.command`. `PostToolUse` also includes `tool_response`. `UserPromptSubmit` adds `prompt`. `Stop` adds `stop_hook_active` and `last_assistant_message`.
+Turn-scoped events add `turn_id`. Tool events add `tool_name`, `tool_use_id`, and `tool_input`; for `Bash` and `apply_patch`, the command is in `tool_input.command`. `PostToolUse` also includes `tool_response`. `UserPromptSubmit` adds `prompt`. `Stop` adds `stop_hook_active` and `last_assistant_message`.
 
 </hfoption>
 <hfoption id="OpenCode">
@@ -244,15 +245,15 @@ Also supported: top-level `continue`, `stopReason`, `suppressOutput`, `systemMes
 - `0` — success.
 - `2` with stderr message — block or continue per event.
 
-**JSON on stdout** mirrors Claude Code's shape:
+**JSON on stdout** uses a shape similar to Claude Code's:
 
 ```json
 {
-  "continue": true,
   "systemMessage": "Injected context for the model",
   "hookSpecificOutput": {
     "hookEventName": "PreToolUse",
-    "permissionDecision": "deny"
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "No network access in this project"
   }
 }
 ```

--- a/units/en/unit5/introduction.mdx
+++ b/units/en/unit5/introduction.mdx
@@ -2,7 +2,7 @@
 
 ## What Are Hooks?
 
-Hooks are user-defined handlers that run at deterministic points in an agent's lifecycle. When an agent is about to call a tool, finish a turn, or start a new session, the runtime pauses, invokes any hooks registered for that event, and then continues. Hooks let you observe what the agent is doing, block unsafe actions, inject extra context, or stream events to an external system. Crucially, without asking the model to do it itself.
+Hooks are user-defined handlers that run at deterministic points in an agent's lifecycle. When an agent is about to call a tool, finish a turn, or start a new session, the runtime pauses, invokes any hooks registered for that event, and then continues. Hooks let you observe what the agent is doing, block unsafe actions, inject extra context, or stream events to an external system. Crucially, they let you do this without asking the model to do it itself.
 
 ```text
 User prompt
@@ -26,7 +26,12 @@ Skills, MCP, plugins, and subagents all shape *what the agent can do*. Hooks sha
 
 ## Why Hooks Matter
 
-A model asked to "always run the linter after editing" will eventually forget or may not be consistent in its implementation. A hook on `PostToolUse` that runs the linter is the same every time. Hooks turn conventions into code. Three common patterns benefit the most:
+A model asked to "always run the linter after editing" will eventually forget or may not be consistent in its implementation. A hook on `PostToolUse` that runs the linter is consistent every single time and always runs. Hooks turn conventions into code.
+
+> [!NOTE]
+> A linter is a tool that checks code for common mistakes, style issues, and project rule violations. It does not usually run the whole program; it scans the code and reports things that look wrong or inconsistent.
+
+Three common patterns benefit the most:
 
 **Observability.** Every tool call, prompt, and stop event can be captured in a log or dashboard so you can see what the agent actually did — not what it said it did.
 
@@ -36,20 +41,21 @@ A model asked to "always run the linter after editing" will eventually forget or
 
 ## Platform Landscape
 
-The three platforms in this course all support hooks, but with different shapes:
+The four platforms in this course all support hooks, but with different shapes:
 
 - **Claude Code** — JSON configuration in `.claude/settings.json` (or inside a plugin). Events use `PascalCase` names like `PreToolUse` and `Stop`. Hooks can be shell commands, HTTP endpoints, prompts, or subagents.
 - **Codex** — JSON configuration in `.codex/hooks.json`, gated behind a feature flag in `config.toml`. A smaller set of events (also `PascalCase`), and shell-command handlers that receive a JSON payload on stdin.
 - **OpenCode** — TypeScript/JavaScript plugin modules in `.opencode/plugins/`. Hooks are object keys on the exported plugin, like `"tool.execute.before"` or a generic `event` callback. There is no JSON event config — everything is code.
+- **Pi** — TypeScript/JavaScript extensions in `.pi/extensions/` or `~/.pi/agent/extensions/`. Events use `lower_snake_case` names like `before_agent_start`, `tool_call`, and `tool_result`, and handlers are registered in code with `pi.on(...)`.
 
-The mental model is consistent across all three: events fire, handlers run, and handlers can influence the agent's next step. Only the syntax and the event names change.
+The mental model is consistent across all four: events fire, handlers run, and handlers can influence the agent's next step. Only the syntax and the event names change.
 
 ## What You'll Build
 
-This unit walks through the hook lifecycle, shows the exact config shape for each platform, and then builds a working **Agent Activity Dashboard**: a Gradio app that receives hook events over HTTP and visualizes tool calls, prompts, and sessions in real time. By the end you will have one dashboard that works against all three agents.
+This unit walks through the hook lifecycle, shows the exact config shape for each platform, and then builds a working **Agent Activity Dashboard**: a Gradio app that receives hook events over HTTP and visualizes tool calls, prompts, and sessions in real time. By the end you will have one dashboard that works against all four agents.
 
 ## What You'll Learn
 
-This unit covers the common hook lifecycle shared by Claude Code, Codex, and OpenCode; where hook configuration lives on each platform and what JSON or code shape it takes; how hook handlers influence the agent through exit codes, JSON output, or thrown errors; and how to build a Gradio dashboard that turns hook events into a live view of agent activity.
+This unit covers the common hook lifecycle shared by Claude Code, Codex, OpenCode, and Pi; where hook configuration lives on each platform and what JSON or code shape it takes; how hook handlers influence the agent through exit codes, JSON output, thrown errors, or returned values; and how to build a Gradio dashboard that turns hook events into a live view of agent activity.
 
 Next, a tour of the hook events themselves.

--- a/units/en/unit5/quiz1.mdx
+++ b/units/en/unit5/quiz1.mdx
@@ -1,6 +1,6 @@
 # Quiz 1: Hook Fundamentals
 
-Test your understanding of hooks, the events they cover, and how they differ across Claude Code, Codex, and OpenCode.
+Test your understanding of hooks, the events they cover, and how they differ across Claude Code, Codex, OpenCode, and Pi.
 
 ## Question 1: What is a hook?
 
@@ -31,21 +31,21 @@ Test your understanding of hooks, the events they cover, and how they differ acr
 <Question
   choices={[
     {
-      text: "Claude Code uses PascalCase JSON events (PreToolUse, Stop); Codex uses a smaller PascalCase JSON set behind a feature flag; OpenCode uses TS/JS plugin modules with keys like 'tool.execute.before'",
-      explain: "Correct! The three platforms share the same lifecycle but differ in syntax and surface.",
+      text: "Claude Code uses PascalCase JSON events (PreToolUse, Stop); Codex uses a smaller PascalCase JSON set behind a feature flag; OpenCode uses TS/JS plugin modules; Pi uses TS/JS extensions with lower_snake_case events like tool_call",
+      explain: "Correct! The four platforms share the same lifecycle but differ in syntax and surface.",
       correct: true
     },
     {
-      text: "All three platforms use the exact same settings.json format for hook events",
-      explain: "False. Only Claude Code uses settings.json. Codex uses hooks.json, and OpenCode uses code-first plugins."
+      text: "All four platforms use the exact same settings.json format for hook events",
+      explain: "False. Only Claude Code uses settings.json. Codex uses hooks.json, OpenCode uses code-first plugins, and Pi uses extensions."
     },
     {
       text: "OpenCode exposes hooks through JSON configuration, like Claude Code",
       explain: "False. OpenCode has no JSON event config — plugins are TS/JS modules exporting hook handlers as object keys."
     },
     {
-      text: "Only Claude Code supports HTTP hooks; Codex and OpenCode only support shell commands",
-      explain: "Close but not quite. Claude Code's 'http' handler type is unique, but Codex command hooks can call curl, and OpenCode plugins can call fetch() — both achieve HTTP delivery."
+      text: "Only Claude Code supports HTTP hooks; Codex, OpenCode, and Pi cannot send events to an HTTP receiver",
+      explain: "Close but not quite. Claude Code's 'http' handler type is unique, but Codex command hooks can call curl, and OpenCode and Pi extensions can call fetch() — all can deliver events to HTTP."
     }
   ]}
 />
@@ -60,7 +60,7 @@ Test your understanding of hooks, the events they cover, and how they differ acr
     },
     {
       text: "UserPromptSubmit fires when the user submits a prompt, before the model sees it — ideal for injecting extra context",
-      explain: "Correct! This is the right event for prepending or modifying the prompt, and both Claude Code and Codex support it.",
+      explain: "Correct! This is the right event for prepending or modifying the prompt. Claude Code and Codex support UserPromptSubmit directly; Pi's nearest equivalent is before_agent_start.",
       correct: true
     },
     {
@@ -68,8 +68,8 @@ Test your understanding of hooks, the events they cover, and how they differ acr
       explain: "False. Stop fires at the end of each turn; SessionEnd (Claude Code) is the session-level event."
     },
     {
-      text: "PostToolUse in Codex fires for every tool, just like in Claude Code",
-      explain: "False. Codex PreToolUse and PostToolUse currently fire for the Bash tool only. Claude Code fires them for every tool."
+      text: "PostToolUse in Codex fires for every possible tool path, just like in Claude Code",
+      explain: "False. Codex PreToolUse and PostToolUse cover supported tool calls such as Bash, apply_patch, and MCP tools, but the surface is narrower than Claude Code's."
     }
   ]}
 />
@@ -93,7 +93,7 @@ Test your understanding of hooks, the events they cover, and how they differ acr
     },
     {
       text: "Hooks cannot block or modify tool calls; they are observe-only",
-      explain: "False. All three platforms support influencing the agent: Claude Code and Codex via exit codes or JSON output, OpenCode via mutating `output` or throwing."
+      explain: "False. All four platforms support influencing the agent: Claude Code and Codex via exit codes or JSON output, OpenCode via mutating `output` or throwing, and Pi via returned values or event mutation."
     }
   ]}
 />
@@ -131,7 +131,7 @@ If you got 4-5 correct, you understand the core hook model well enough to start 
 ## Key Takeaways
 
 - Hooks are deterministic runtime handlers, not prompts or plugins
-- Claude Code, Codex, and OpenCode expose similar lifecycle moments with different configuration surfaces
+- Claude Code, Codex, OpenCode, and Pi expose similar lifecycle moments with different configuration surfaces
 - Hooks are the right tool when behavior must happen every time rather than relying on the model to remember
 
 ## Next Steps

--- a/units/en/unit5/quiz2.mdx
+++ b/units/en/unit5/quiz2.mdx
@@ -16,8 +16,8 @@ Test your ability to wire hooks into real workflows.
       correct: true
     },
     {
-      text: "You can only receive hook events from Claude Code — Codex and OpenCode cannot post JSON",
-      explain: "False. All three platforms can POST JSON to an HTTP endpoint: Claude Code uses `type: \"http\"`, Codex pipes the stdin payload to `curl`, and OpenCode plugins call `fetch()`."
+      text: "You can only receive hook events from Claude Code — Codex, OpenCode, and Pi cannot post JSON",
+      explain: "False. All four platforms can POST JSON to an HTTP endpoint: Claude Code uses `type: \"http\"`, Codex pipes the stdin payload to `curl`, and OpenCode plugins and Pi extensions call `fetch()`."
     },
     {
       text: "Hook events should be written to a file rather than served over HTTP",
@@ -103,13 +103,13 @@ Test your ability to wire hooks into real workflows.
 <Question
   choices={[
     {
-      text: "The same dashboard works for Claude Code, Codex, and OpenCode because the server normalizes three different payload shapes into one consistent record",
+      text: "The same dashboard works for Claude Code, Codex, OpenCode, and Pi because the server normalizes four different payload shapes into one consistent record",
       explain: "Correct! The `_normalize` function maps each platform's field names onto `{platform, event, tool, args}` so the UI doesn't need platform-specific branches.",
       correct: true
     },
     {
       text: "The dashboard only works for one platform at a time; you must redeploy it when switching agents",
-      explain: "False. The normalizer accepts any of the three platforms simultaneously — they just arrive with different `X-Platform` values."
+      explain: "False. The normalizer accepts any of the four platforms simultaneously — they just arrive with different platform values from either the body or headers."
     },
     {
       text: "OpenCode events are incompatible with the same receiver because OpenCode plugins can't make HTTP calls",
@@ -117,7 +117,7 @@ Test your ability to wire hooks into real workflows.
     },
     {
       text: "You have to run a separate dashboard per platform, then merge the logs afterwards",
-      explain: "False. A single receiver handles all three because they can all POST JSON to the same URL."
+      explain: "False. A single receiver handles all four because they can all POST JSON to the same URL."
     }
   ]}
 />
@@ -130,7 +130,7 @@ If you got 4-5 correct, you can wire hooks into a real observability and guardra
 
 - One FastAPI + Gradio process is enough for a lightweight live dashboard
 - Hook handlers should fail fast, sanitize payloads, and avoid shell-injection patterns
-- A shared receiver works across Claude Code, Codex, and OpenCode once you normalize the event shape
+- A shared receiver works across Claude Code, Codex, OpenCode, and Pi once you normalize the event shape
 
 ## What's Next
 


### PR DESCRIPTION
## Summary

This PR updates Unit 5 to better reflect the current hook platform coverage and technical details, and refreshes Atin's instructor bio in Unit 0.


## Changes

- Add Pi to the Unit 5 platform overview, hook lifecycle comparison, dashboard example, directory layout, and quizzes
- Update references from three hook platforms to four across the Unit 5 lesson flow
- Clarify Codex hook behavior, including supported tool events, payload fields, `PermissionRequest`, and version-sensitive details
- Improve Codex dashboard snippets by documenting `jq`/`curl` requirements, using `args` for tool responses, and making telemetry best-effort when the dashboard is offline
- Replace the `rm -rf ~/` guardrail demo with a disposable `/tmp` test folder to avoid asking learners to run a destructive home-directory command
- Add a short learner-facing note explaining what linters check
- Update Atin's instructor bio in the Unit 0 introduction

